### PR TITLE
Fix Secrets Manager Secret with no version crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-06-18
+
+### Fixed
+
+-   Secrets Manager loader now skips secrets that have no `AWSCURRENT` version instead of crashing with `ResourceNotFoundException`.
+
 ## [1.1.0] - 2024-05-16
 
 -   Added support for AWS Secrets Manager.
@@ -40,7 +46,9 @@
 
 -   Initial release.
 
-[unreleased]: https://github.com/mathandpencil/layered-settings/compare/v1.0.5..HEAD
+[unreleased]: https://github.com/mathandpencil/layered-settings/compare/v1.1.1..HEAD
+[1.1.1]: https://github.com/mathandpencil/layered-settings/compare/v1.1.0..v1.1.1
+[1.1.0]: https://github.com/mathandpencil/layered-settings/compare/v1.0.5..v1.1.0
 [1.0.5]: https://github.com/mathandpencil/layered-settings/releases/tag/v1.0.5
 [1.0.3]: https://github.com/mathandpencil/layered-settings/releases/tag/v1.0.3
 [1.0.2]: https://github.com/mathandpencil/layered-settings/releases/tag/v1.0.2

--- a/layered_settings/loaders/secrets_manager_loader.py
+++ b/layered_settings/loaders/secrets_manager_loader.py
@@ -78,7 +78,11 @@ def _load_from_secrets_manager(path, aws_region):
         # otherwise, the secret_key will remain intact and the plaintext value will assigned to it.
         arn = secret["ARN"]
         key = secret["Name"][len(path) :]
-        secret_string = secrets_manager_client.get_secret_value(SecretId=arn)["SecretString"]
+        try:
+            secret_string = secrets_manager_client.get_secret_value(SecretId=arn)["SecretString"]
+        except secrets_manager_client.exceptions.ResourceNotFoundException:
+            logger.warning(f"{secret['Name']} does not contain an AWSCURRENT version! Skipping...")
+            continue
         try:
             secret = json.loads(secret_string)
             key = key.split("/")[0]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="layered-settings",
-    version="1.1.0",
+    version="1.1.1",
     description="Flexible, simple, extensible settings loader from environment, AWS SSM, AWS Secrets Manager, configparser .ini, and more.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -136,8 +136,7 @@ class SecretsManagerLoaderTests(unittest.TestCase):
         return patch.object(secrets_manager_loader, "boto3", boto3_mock)
 
     def test_skips_secret_without_awscurrent_version(self):
-        """A secret with no AWSCURRENT version is skipped, not fatal, and does
-        not leak the previous secret's value into its key."""
+        """A secret with no AWSCURRENT version is skipped."""
         path = "/shared/global/"
         with self._patched_loader(
             {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,9 +1,10 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from layered_settings import initialize_settings
 from layered_settings import loaders
+from layered_settings.loaders import secrets_manager_loader
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -92,3 +93,75 @@ class LayeredSettingsTests(unittest.TestCase):
             self.assertEqual("env11", get_setting("section1", "key1"))
             self.assertEqual("override21", get_setting("section2", "key1"))
             self.assertEqual("default22", get_setting("section2", "key2"))
+
+
+# Sentinel: a secret whose Name maps to this has no AWSCURRENT version,
+# so get_secret_value should raise ResourceNotFoundException.
+_NO_AWSCURRENT = object()
+
+
+class SecretsManagerLoaderTests(unittest.TestCase):
+    def _patched_loader(self, secret_strings):
+        """Return a context manager patching the loader's boto3 with a mock
+        secretsmanager client.
+
+        ``secret_strings`` maps a secret Name to its SecretString, or to
+        ``_NO_AWSCURRENT`` to simulate a secret with no AWSCURRENT version.
+        """
+
+        class ResourceNotFoundException(Exception):
+            pass
+
+        client = MagicMock()
+        client.exceptions.ResourceNotFoundException = ResourceNotFoundException
+
+        names = list(secret_strings)
+        client.list_secrets.return_value = {
+            "SecretList": [{"Name": name, "ARN": f"arn:{name}"} for name in names]
+        }
+        arn_to_name = {f"arn:{name}": name for name in names}
+
+        def get_secret_value(SecretId):
+            value = secret_strings[arn_to_name[SecretId]]
+            if value is _NO_AWSCURRENT:
+                raise ResourceNotFoundException(
+                    "Secrets Manager can't find the specified secret value for staging label: AWSCURRENT"
+                )
+            return {"SecretString": value}
+
+        client.get_secret_value.side_effect = get_secret_value
+
+        boto3_mock = MagicMock()
+        boto3_mock.client.return_value = client
+        return patch.object(secrets_manager_loader, "boto3", boto3_mock)
+
+    def test_skips_secret_without_awscurrent_version(self):
+        """A secret with no AWSCURRENT version is skipped, not fatal, and does
+        not leak the previous secret's value into its key."""
+        path = "/shared/global/"
+        with self._patched_loader(
+            {
+                "/shared/global/section1/key1": "good-value",
+                "/shared/global/section2/key1": _NO_AWSCURRENT,
+                "/shared/global/section3/key1": "also-good",
+            }
+        ):
+            settings = secrets_manager_loader._load_from_secrets_manager(path, "us-east-1")
+
+        self.assertEqual("good-value", settings["section1/key1"])
+        self.assertEqual("also-good", settings["section3/key1"])
+        # The bad secret must be skipped entirely, not present with a stale value.
+        self.assertNotIn("section2/key1", settings)
+
+    def test_json_secret_is_flattened(self):
+        """A JSON secret string is flattened into section/subkey entries."""
+        path = "/shared/global/"
+        with self._patched_loader(
+            {
+                "/shared/global/section1/anything": '{"key1": "v1", "key2": "v2"}',
+            }
+        ):
+            settings = secrets_manager_loader._load_from_secrets_manager(path, "us-east-1")
+
+        self.assertEqual("v1", settings["section1/key1"])
+        self.assertEqual("v2", settings["section1/key2"])


### PR DESCRIPTION
### Test Plan
```
❯ uv run python -m unittest tests.tests -v 

test_dict_settings (tests.tests.LayeredSettingsTests.test_dict_settings) ... Failed to find [section1] key1 in [{'general': {'CLIENT_NAME': 'client'}}].
ok
test_empty_settings (tests.tests.LayeredSettingsTests.test_empty_settings) ... Failed to find [section1] key1 in [].
ok
test_env_settings (tests.tests.LayeredSettingsTests.test_env_settings) ... Failed to find [section1] key1 in [<layered_settings.loaders.env_loader.EnvLoader object at 0x7fbdc3429fd0>].
Failed to find [section2] key2 in [<layered_settings.loaders.env_loader.EnvLoader object at 0x7fbdc3429fd0>].
ok
test_env_settings_with_hyphen (tests.tests.LayeredSettingsTests.test_env_settings_with_hyphen) ... Failed to find [section-1] key1 in [<layered_settings.loaders.env_loader.EnvLoader object at 0x7fbdc34507d0>].
ok
test_normal_usage (tests.tests.LayeredSettingsTests.test_normal_usage) ... ok
test_json_secret_is_flattened (tests.tests.SecretsManagerLoaderTests.test_json_secret_is_flattened)
A JSON secret string is flattened into section/subkey entries. ... ok
test_skips_secret_without_awscurrent_version (tests.tests.SecretsManagerLoaderTests.test_skips_secret_without_awscurrent_version)
A secret with no AWSCURRENT version is skipped, not fatal, and does ... /shared/global/section2/key1 does not contain an AWSCURRENT version! Skipping...
ok

----------------------------------------------------------------------
Ran 7 tests in 0.004s

OK
```